### PR TITLE
Fix PowerShell version detection

### DIFF
--- a/Get-O365SKUsInfos.psm1
+++ b/Get-O365SKUsInfos.psm1
@@ -123,7 +123,7 @@ function Get-O365SKUCatalog {
             throw "not able to create HTMLFile com object"
         }
         try {
-            if ($host.Version.Major -gt 5) {
+            if ($PSVersionTable.PSVersion.Major -gt 5) {
                 $encodedhtmlcontent = [System.Text.Encoding]::Unicode.GetBytes($htmlcontent)
                 $htmlobj.write($encodedhtmlcontent)
             } else {


### PR DESCRIPTION
The $host variable does not always reflect the engine version. Using the $PSVersionTable variable allows this to be ran on hosting applications such as VS Code without errors.